### PR TITLE
Properly remove unregistered role

### DIFF
--- a/index.js
+++ b/index.js
@@ -152,6 +152,14 @@ bot.on("message", message => {
         commands[cmd](message);
 });
 
+bot.on("guildMemberUpdate", (_old, current) => {
+    if (
+        current.roles.cache.has(settings.discord.roles.registered) &&
+        current.roles.cache.has(settings.discord.roles.unregistered)
+    )
+        current.roles.remove(settings.discord.roles.unregistered, "User has registered");
+});
+
 bot.on("ready", () => {
     bot.user.setActivity(settings.discord.prefix + "mc");
     console.log("Ready!");

--- a/settings.example.json
+++ b/settings.example.json
@@ -9,7 +9,11 @@
         },
         "message": "",
         "prefix": "",
-        "token": ""
+        "token": "",
+        "roles": {
+            "unregistered": "",
+            "registered": ""
+        }
     },
     "refresh": 5e3,
     "server": {


### PR DESCRIPTION
Everytime a member is updated, checks if user has both roles; if so, remove the unregistered role